### PR TITLE
Fix unclear "This applies in all modes" note

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -661,9 +661,7 @@ Opera supported this quirk (copied from IE), but then dropped it because it brok
 
 <p class="status not-tr">Run <a href="http://w3c-test.org/quirks-mode/font-element-text-decoration-color/">tests</a>
 
-<p><!--In <span data-anolis-spec=dom title=concept-document-quirks>quirks mode</span>, t-->The <code>font</code> element must override the color of any text decoration that spans the text of the element to the used value of the element's 'color' property.
-
-<p class=note>This applies in all modes.
+<p>In <span data-anolis-spec=dom title=concept-document-quirks>quirks mode</span> and <span data-anolis-spec=dom title=concept-document-limited-quirks>limited-quirks mode</span>, the <code>font</code> element must override the color of any text decoration that spans the text of the element to the used value of the element's 'color' property.
 
 <h3>The tables inherit color from body quirk</h3>
 


### PR DESCRIPTION
Refs https://www.w3.org/Bugs/Public/show_bug.cgi?id=28635
This fix presumes that the weird presentation here was just an editorial oversight.