### PR TITLE
Remove the font element text decoration color quirk

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -656,14 +656,6 @@ Opera supported this quirk (copied from IE), but then dropped it because it brok
 
 <!-- http://mxr.mozilla.org/mozilla-central/source/layout/generic/nsTextFrameThebes.cpp#4582 -->
 
-<h3>The font element text decoration color quirk</h3>
-
-<p class="status"><a href="http://w3c-test.org/quirks-mode/font-element-text-decoration-color/">Run tests</a>
-
-<p><!--In <span data-anolis-spec=dom title=concept-document-quirks>quirks mode</span>, t-->The <code>font</code> element must override the color of any text decoration that spans the text of the element to the used value of the element's 'color' property.
-
-<p class=note>This applies in all modes.
-
 <h3>The tables inherit color from body quirk</h3>
 
 <p>In <span data-anolis-spec=dom title=concept-document-quirks>quirks mode</span>, the initial value of the 'color' property must be 'quirk-inherit', a special value that has no keyword mapping to it.


### PR DESCRIPTION
Turned out to not technically be a quirk, and as such was moved into the HTML spec.
Follow-up to https://github.com/whatwg/html/pull/42
Refs https://www.w3.org/Bugs/Public/show_bug.cgi?id=28635