### PR TITLE
Meta: use https for dbaron.org (it redirects)

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -19,7 +19,7 @@ Boilerplate: omit conformance, omit feedback-header
 {
     "INTRINSIC": {
         "authors": [ "David Baron" ],
-        "href": "http://dbaron.org/css/intrinsic/",
+        "href": "https://dbaron.org/css/intrinsic/",
         "title": "More Precise Definitions of Intrinsic Widths and Table Layout (Proposal)"
     }
 }
@@ -35,7 +35,7 @@ urlPrefix: https://drafts.csswg.org/css2/
     urlPrefix: box.html
         type: dfn; text: border box; url: #border-edge
         type: dfn; text: content box; url: #content-edge
-urlPrefix: http://dbaron.org/css/intrinsic/
+urlPrefix: https://dbaron.org/css/intrinsic/
     type: dfn;
         text: min-content width of an inline formatting context; url: #inline-intrinsic-min
         text: outer min-content width of a table cell; url: #autotable


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://quirks.spec.whatwg.org/branch-snapshots/https/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/quirks/99f42cf...84a4957.html)