### PR TITLE
Correct affiliation for zcorpan

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -644,8 +644,8 @@ for their useful comments.
 href="https://developer.mozilla.org/en-US/docs/Mozilla/Mozilla_quirks_mode_behavior">Mozilla's
 quirks in MDN</a>.
 
-<p>This standard is written by Simon Pieters (<a href="http://www.opera.com/">Opera Software
-ASA</a>, <a href="mailto:simonp@opera.com">simonp@opera.com</a>).
+<p>This standard is written by Simon Pieters (no affiliation, <a href="http://www.opera.com/">Opera
+Software ASA</a> until 2017-09-15, <a href="mailto:zcorpan@gmail.com">zcorpan@gmail.com</a>).
 
 <p>Per <a href="https://creativecommons.org/publicdomain/zero/1.0/">CC0</a>, to the extent possible
 under law, the editors have waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://quirks.spec.whatwg.org/branch-snapshots/zcorpan/affiliation/) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/quirks/07e55b2...6921b4f.html)