### PR TITLE
Meta: Review Draft infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ deploy_key
 deploy_key.pub
 deploy.sh
 quirks.html
+review.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /quirks.spec.whatwg.org/
-deploy_key
-deploy_key.pub
-deploy.sh
-quirks.html
-review.sh
+/deploy_key
+/deploy_key.pub
+/deploy.sh
+/quirks.html
+/review.sh

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-local: quirks.bs
-	bikeshed spec quirks.bs quirks.html --md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
-
 remote: quirks.bs
 	curl https://api.csswg.org/bikeshed/ -f -F file=@quirks.bs > quirks.html -F md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
 
+local: quirks.bs
+	bikeshed spec quirks.bs quirks.html --md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
+
 deploy: quirks.bs
 	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+
+review: quirks.bs
+	curl --remote-name --fail https://resources.whatwg.org/build/review.sh && bash ./review.sh

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ local: quirks.bs
 	bikeshed spec quirks.bs quirks.html --md-Text-Macro="SNAPSHOT-LINK LOCAL COPY"
 
 deploy: quirks.bs
-	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh && bash ./deploy.sh
+	curl --remote-name --fail https://resources.whatwg.org/build/deploy.sh
+	bash ./deploy.sh
 
 review: quirks.bs
-	curl --remote-name --fail https://resources.whatwg.org/build/review.sh && bash ./review.sh
+	curl --remote-name --fail https://resources.whatwg.org/build/review.sh
+	bash ./review.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repository hosts the [Quirks Mode Standard](https://quirks.spec.whatwg.org/
 
 ### Code of conduct
 
-We are committed to providing a friendly, safe and welcoming environment for all. Please read and
+We are committed to providing a friendly, safe, and welcoming environment for all. Please read and
 respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).
 
 ### Pull requests
@@ -14,12 +14,11 @@ reading through the [WHATWG FAQ](https://whatwg.org/faq) if you are new here.
 Please add your name to the Acknowledgments section in your first pull request, even for trivial
 fixes. The names are sorted lexicographically.
 
-If you want to preview the spec locally, you can either use a locally installed copy of
-[Bikeshed](https://github.com/tabatkins/bikeshed) by running `make` or use the HTTP API version by
-running `make remote`.
+### Building "locally"
 
-If you want to do a complete "local deploy" including commit and/or branch snapshots, run
-`make deploy`.
+For quick local iteration, run `make`. To verify your changes locally, run `make deploy`. See more
+in the
+[WHATWG Contributor Guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md#building).
 
 ### Merge policy
 
@@ -29,4 +28,4 @@ If you can commit to this repository, see the
 ### Tests
 
 Tests can be found in the `quirks/` directory of
-[`web-platform-tests`](https://github.com/w3c/web-platform-tests).
+[web-platform-tests/wpt](https://github.com/web-platform-tests/wpt).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 This repository hosts the [Quirks Mode Standard](https://quirks.spec.whatwg.org/).
 
-### Code of conduct
+## Code of conduct
 
 We are committed to providing a friendly, safe, and welcoming environment for all. Please read and
 respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).
 
-### Pull requests
+## Pull requests
 
 In short, change `quirks.bs` and submit your patch, with a
 [good commit message](https://github.com/whatwg/meta/blob/master/COMMITTING.md). Consider
@@ -14,18 +14,18 @@ reading through the [WHATWG FAQ](https://whatwg.org/faq) if you are new here.
 Please add your name to the Acknowledgments section in your first pull request, even for trivial
 fixes. The names are sorted lexicographically.
 
-### Building "locally"
+## Building "locally"
 
 For quick local iteration, run `make`. To verify your changes locally, run `make deploy`. See more
 in the
 [WHATWG Contributor Guidelines](https://github.com/whatwg/meta/blob/master/CONTRIBUTING.md#building).
 
-### Merge policy
+## Merge policy
 
 If you can commit to this repository, see the
 [WHATWG Maintainer Guidelines](https://github.com/whatwg/meta/blob/master/MAINTAINERS.md).
 
-### Tests
+## Tests
 
 Tests can be found in the `quirks/` directory of
 [web-platform-tests/wpt](https://github.com/web-platform-tests/wpt).


### PR DESCRIPTION
See https://github.com/whatwg/whatwg.org/issues/197 and https://github.com/whatwg/meta/issues/92 for details.

This also updates the web-platform-tests URL.