### PR TITLE
Make constructed stylesheets not support quirks mode

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -240,6 +240,8 @@ above properties in its "Value" grammar.
 supported in the <code><a method for=CSS lt="supports(property, value)">supports()</a></code> static
 method of the {{CSS}} interface.</p>
 
+<p><a>Quirky colors</a> must not be supported on a <a interface>CSSStyleSheet</a> where the <a>constructed flag</a> is set.</p>
+
 <wpt>
  hashless-hex-color/limited-quirks.html
  hashless-hex-color/no-quirks.html
@@ -308,6 +310,8 @@ above properties in its "Value" grammar.
 <p>The <<quirky-length>> value must not be supported in arguments to CSS expressions other than the
 <a>rect()</a> expression, and must not be supported in the <code><a method for=CSS
 lt="supports(property, value)">supports()</a></code> static method of the {{CSS}} interface.</p>
+
+<p><a>Quirky lengths</a> must not be supported on a <a interface>CSSStyleSheet</a> where the <a>constructed flag</a> is set.</p>
 
 <wpt>
  unitless-length/limited-quirks.html


### PR DESCRIPTION
Constructed stylesheets should not support quirks mode. See https://github.com/WICG/construct-stylesheets/issues/59. I'm not sure if I need to make a WPT for this and how to link from a draft spec. I guess this shouldn't be merged until constructable stylesheets are part of CSSOM?

cc @domenic 