### PR TITLE
Don't apply percentage height quirk to grid and flex containers

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -350,7 +350,7 @@ the first step that returns a value:
 
 <ol>
 
- <li><p>Let |element| be the nearest ancestor <a>block container box</a> of |element|, if there is
+ <li><p>Let |element| be the nearest ancestor <a>containing block</a> of |element|, if there is
  one. Otherwise, return the <a>initial containing block</a>.
 
  <li><p>If |element| has a <a>computed value</a> of the 'display' property that is
@@ -360,8 +360,8 @@ the first step that returns a value:
  ''height/auto'', then return |element|.
 
  <li><p>If |element| has a <a>computed value</a> of the 'position' property that is
- ''position/absolute'', or if |element| is a <a>grid container</a> or a <a>flex container</a>,
- then return |element|.
+ ''position/absolute'', or if |element| is a not a <a>block container</a> or a
+ <a>table wrapper box</a>, then return |element|.
 
  <li><p>Jump to the first step.
 

--- a/quirks.bs
+++ b/quirks.bs
@@ -95,14 +95,6 @@ different modes have since gained a few differences outside of CSS.
   href="https://bugs.chromium.org/p/chromium/issues/detail?id=369979">Chromium has removed a quirk
   where display was forced to table or inline-table on <code>table</code> elements</a>.</p>
 
-<<<<<<< HEAD
-=======
-  <wpt>
-   historical/list-item-bullet-size.html
-   historical/vertical-align-in-quirks.html
-  </wpt>
-
->>>>>>> List remaining test - https://github.com/web-platform-tests/wpt/pull/15381
  <li>
 
   <p>Get interoperability on quirks that <em>are</em> needed for Web compatibility.

--- a/quirks.bs
+++ b/quirks.bs
@@ -57,6 +57,7 @@ spec:selectors-4; type:selector
  }
 </style>
 
+<wpt-rest></wpt-rest><!-- https://github.com/web-platform-tests/wpt/issues/15354 -->
 
 <h2 id=introduction>Introduction</h2>
 
@@ -353,13 +354,14 @@ the first step that returns a value:
  one. Otherwise, return the <a>initial containing block</a>.
 
  <li><p>If |element| has a <a>computed value</a> of the 'display' property that is
- ''display/table-cell'', return a UA-defined value.
+ ''display/table-cell'', then return a UA-defined value.
 
  <li><p>If |element| has a <a>computed value</a> of the 'height' property that is not
- ''height/auto'', return |element|.
+ ''height/auto'', then return |element|.
 
  <li><p>If |element| has a <a>computed value</a> of the 'position' property that is
- ''position/absolute'', return |element|.
+ ''position/absolute'', or if |element| is a <a>grid container</a> or a <a>flex container</a>,
+ then return |element|.
 
  <li><p>Jump to the first step.
 
@@ -369,7 +371,7 @@ the first step that returns a value:
 CSS. This specification does not try to specify what to use as the containing block for calculating
 percentage heights in tables. Godspeed!
 
-<p class=issue>This quirk needs to take writing modes into account and maybe bail for grids.</p>
+<p class=big-issue>This quirk needs to take writing modes into account.</p>
 
 
 <h3 algorithm id=the-html-element-fills-the-viewport-quirk>The <{html}> element fills the viewport

--- a/quirks.bs
+++ b/quirks.bs
@@ -57,6 +57,7 @@ spec:selectors-4; type:selector
  }
 </style>
 
+
 <h2 id=introduction>Introduction</h2>
 
 <h3 id=history>History</h3>

--- a/quirks.bs
+++ b/quirks.bs
@@ -57,8 +57,6 @@ spec:selectors-4; type:selector
  }
 </style>
 
-<wpt-rest></wpt-rest><!-- https://github.com/web-platform-tests/wpt/issues/15354 -->
-
 <h2 id=introduction>Introduction</h2>
 
 <h3 id=history>History</h3>
@@ -97,6 +95,14 @@ different modes have since gained a few differences outside of CSS.
   href="https://bugs.chromium.org/p/chromium/issues/detail?id=369979">Chromium has removed a quirk
   where display was forced to table or inline-table on <code>table</code> elements</a>.</p>
 
+<<<<<<< HEAD
+=======
+  <wpt>
+   historical/list-item-bullet-size.html
+   historical/vertical-align-in-quirks.html
+  </wpt>
+
+>>>>>>> List remaining test - https://github.com/web-platform-tests/wpt/pull/15381
  <li>
 
   <p>Get interoperability on quirks that <em>are</em> needed for Web compatibility.


### PR DESCRIPTION
Fixes #39.

cc @mstensho


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/quirks/40.html" title="Last updated on Mar 29, 2019, 11:33 AM UTC (75f8ef3)">Preview</a> | <a href="https://whatpr.org/quirks/40/be737a9...75f8ef3.html" title="Last updated on Mar 29, 2019, 11:33 AM UTC (75f8ef3)">Diff</a>