### PR TITLE
Remove an incorrect issue that claimed a test to be wrong

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -443,11 +443,6 @@ property of ''box-sizing/border-box'', but only for the purpose of the 'height',
 
 <h2 id=selectors>Selectors</h2>
 
-<p class=big-issue>The following test appears to be invalid. See <a
-href="https://bugs.chromium.org/p/chromium/issues/detail?id=733682#c20">chromium issue
-733682</a>.</p>
-
-
 <h3 algorithm id=the-active-and-hover-quirk>The :active and :hover quirk</h3>
 
 <p>In <a spec=dom>quirks mode</a>, a <a>compound selector</a> |selector| that matches the following


### PR DESCRIPTION
See https://bugs.chromium.org/p/chromium/issues/detail?id=733682#c22

---

cc @tkent-google


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/quirks/44.html" title="Last updated on Oct 14, 2024, 1:56 PM UTC (0a80ef3)">Preview</a> | <a href="https://whatpr.org/quirks/44/ec09b50...0a80ef3.html" title="Last updated on Oct 14, 2024, 1:56 PM UTC (0a80ef3)">Diff</a>