### PR TITLE
Fix typo in body element fills the html element quirk

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -437,7 +437,7 @@ the following algorithm:
 <ol>
 
  <li><p>Let |margins| be the sum of the <a>used values</a> of the 'margin-left' and 'margin-right'
- properties of |body| if |body| has a <a>vertical writing mode</a>, otherwise |margins| it be the
+ properties of |body| if |body| has a <a>vertical writing mode</a>, otherwise let |margins| be the
  sum of the <a>used values</a> of the 'margin-top' and 'margin-bottom' properties of |body|.
 
  <li><p>Let |size| be the size of |body|'s parent element's <a>content box</a> in the <a>block flow
@@ -610,6 +610,7 @@ conditions must not match elements that would not also match the '':any-link'' s
 Anne van Kesteren,
 Boris Zbarsky,
 Chris Rebert,
+Dan Mulvey,
 David Baron,
 Kang-Hao Lu,
 Ms2ger,


### PR DESCRIPTION
Fixes #26 

Change 'otherwise margins it be' to 'otherwise let margins be'


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/quirks/45.html" title="Last updated on Jun 18, 2019, 6:38 AM UTC (1daa1ba)">Preview</a> | <a href="https://whatpr.org/quirks/45/6b8e8d9...1daa1ba.html" title="Last updated on Jun 18, 2019, 6:38 AM UTC (1daa1ba)">Diff</a>