### PR TITLE
Meta: Fix link defaults

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -41,12 +41,15 @@ spec:css2; type:property;
 spec:css-sizing-3
     type:property; text:box-sizing
     type:value; for:box-sizing; text:border-box
+    type:value; for:width; text:auto
+    type:value; for:height; text:auto
 spec:css-tables-3; type:property; text:border-spacing
 spec:css-color-4; type:property; text:color
 spec:cssom-1; type:interface; text:CSS
 spec:selectors-4; type:selector
     text::active
     text::hover
+spec:css-page-floats-3; type:value; text:none
 </pre>
 
 <style>


### PR DESCRIPTION
This should fix the build error for #53


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/quirks/54.html" title="Last updated on Sep 30, 2020, 9:20 AM UTC (bd7c7bb)">Preview</a> | <a href="https://whatpr.org/quirks/54/58c38de...bd7c7bb.html" title="Last updated on Sep 30, 2020, 9:20 AM UTC (bd7c7bb)">Diff</a>