### PR TITLE
Fix broken cross-reference 'quirky colors'

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -114,8 +114,8 @@ different modes have since gained a few differences outside of CSS.
   <p>Where possible, limit quirks to a fixed set of legacy features so they don't propagate into
   new features.
 
-  <p class=example id=example-limit-quirks>For example, <a>quirky colors</a> are limited to a fixed
-  set of CSS properties so that they do not apply in SVG features that also accept colors, or in <a
+  <p class=example id=example-limit-quirks>For example, [[#the-hashless-hex-color-quirk]] is limited to a fixed
+  set of CSS properties so that the quirk does not apply in SVG features that also accept colors, or in <a
   href="https://bugs.webkit.org/show_bug.cgi?id=153730">CSS gradients where the grammar could
   otherwise become ambiguous</a>.
 


### PR DESCRIPTION
Fixes #65.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/quirks/66.html" title="Last updated on Feb 21, 2022, 3:35 PM UTC (4a5e05e)">Preview</a> | <a href="https://whatpr.org/quirks/66/a349dca...4a5e05e.html" title="Last updated on Feb 21, 2022, 3:35 PM UTC (4a5e05e)">Diff</a>