### PR TITLE
Meta: fix link error for 'body'

### DIFF
--- a/quirks.bs
+++ b/quirks.bs
@@ -77,6 +77,8 @@ spec:css-display-4
     type:property; text:display
     type:dfn; text:containing block
     type:dfn; text:initial containing block
+spec:html
+    type:element; text:body
 </pre>
 
 <style>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/quirks/81.html" title="Last updated on Apr 8, 2025, 10:47 AM UTC (afed1c1)">Preview</a> | <a href="https://whatpr.org/quirks/81/da592b3...afed1c1.html" title="Last updated on Apr 8, 2025, 10:47 AM UTC (afed1c1)">Diff</a>